### PR TITLE
【FEAT】問題の数字を上部に固定で表示

### DIFF
--- a/PrimePickApp.xcodeproj/project.pbxproj
+++ b/PrimePickApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4F0C82842BC8247500E1480E /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0C82832BC8247500E1480E /* MainView.swift */; };
 		4F0C82862BC8247600E1480E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F0C82852BC8247600E1480E /* Assets.xcassets */; };
 		4F0C828A2BC8247600E1480E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F0C82892BC8247600E1480E /* Preview Assets.xcassets */; };
+		4F42C7A42BF76E7700F92FBB /* QuizNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */; };
 		4F8BE16C2BF4FFB000D7CF0E /* PrimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8BE16B2BF4FFB000D7CF0E /* PrimeData.swift */; };
 		4F8BE16E2BF504BB00D7CF0E /* QuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */; };
 /* End PBXBuildFile section */
@@ -26,6 +27,7 @@
 		4F0C82852BC8247600E1480E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4F0C82872BC8247600E1480E /* PrimePickApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PrimePickApp.entitlements; sourceTree = "<group>"; };
 		4F0C82892BC8247600E1480E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizNumberView.swift; sourceTree = "<group>"; };
 		4F8BE16B2BF4FFB000D7CF0E /* PrimeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeData.swift; sourceTree = "<group>"; };
 		4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizView.swift; sourceTree = "<group>"; };
 		4FC177B82BEEAB2C00447A06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				4F0C82812BC8247500E1480E /* PrimePickApp.swift */,
 				4F0C82832BC8247500E1480E /* MainView.swift */,
 				4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */,
+				4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */,
 				4F8BE1682BF4FB8E00D7CF0E /* QuizData */,
 				4F0C82852BC8247600E1480E /* Assets.xcassets */,
 				4F0C82872BC8247600E1480E /* PrimePickApp.entitlements */,
@@ -161,6 +164,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F42C7A42BF76E7700F92FBB /* QuizNumberView.swift in Sources */,
 				4F02A57D2BF62F61003DF310 /* PrimeQuizEntity.swift in Sources */,
 				4F0C82842BC8247500E1480E /* MainView.swift in Sources */,
 				4F8BE16E2BF504BB00D7CF0E /* QuizView.swift in Sources */,

--- a/PrimePickApp.xcodeproj/project.pbxproj
+++ b/PrimePickApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4F0C82862BC8247600E1480E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F0C82852BC8247600E1480E /* Assets.xcassets */; };
 		4F0C828A2BC8247600E1480E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F0C82892BC8247600E1480E /* Preview Assets.xcassets */; };
 		4F42C7A42BF76E7700F92FBB /* QuizNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */; };
+		4F42C7A62BF7756200F92FBB /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F42C7A52BF7756200F92FBB /* ColorAssets.xcassets */; };
 		4F8BE16C2BF4FFB000D7CF0E /* PrimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8BE16B2BF4FFB000D7CF0E /* PrimeData.swift */; };
 		4F8BE16E2BF504BB00D7CF0E /* QuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */; };
 /* End PBXBuildFile section */
@@ -28,6 +29,7 @@
 		4F0C82872BC8247600E1480E /* PrimePickApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PrimePickApp.entitlements; sourceTree = "<group>"; };
 		4F0C82892BC8247600E1480E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizNumberView.swift; sourceTree = "<group>"; };
+		4F42C7A52BF7756200F92FBB /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		4F8BE16B2BF4FFB000D7CF0E /* PrimeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeData.swift; sourceTree = "<group>"; };
 		4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizView.swift; sourceTree = "<group>"; };
 		4FC177B82BEEAB2C00447A06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */,
 				4F8BE1682BF4FB8E00D7CF0E /* QuizData */,
 				4F0C82852BC8247600E1480E /* Assets.xcassets */,
+				4F42C7A52BF7756200F92FBB /* ColorAssets.xcassets */,
 				4F0C82872BC8247600E1480E /* PrimePickApp.entitlements */,
 				4F0C82882BC8247600E1480E /* Preview Content */,
 			);
@@ -153,6 +156,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F0C828A2BC8247600E1480E /* Preview Assets.xcassets in Resources */,
+				4F42C7A62BF7756200F92FBB /* ColorAssets.xcassets in Resources */,
 				4F0C82862BC8247600E1480E /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PrimePickApp/ColorAssets.xcassets/Contents.json
+++ b/PrimePickApp/ColorAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PrimePickApp/ColorAssets.xcassets/appGreen.colorset/Contents.json
+++ b/PrimePickApp/ColorAssets.xcassets/appGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xDD",
+          "red" : "0x77"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -13,7 +13,7 @@ struct QuizNumberView: View {
     
     var body: some View {
         ZStack {
-            Color.cyan
+            Color("appGreen")
             
             Text(quizData[quizNumber].number.description)
                 .font(.custom("ArialRoundedMTBold", size: 180))

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -8,11 +8,18 @@
 import SwiftUI
 
 struct QuizNumberView: View {
+    @Binding var quizNumber: Int
+    let quizData: [PrimeQuizEntity]
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text(quizData[quizNumber].number.description)
     }
 }
 
-#Preview {
-    QuizNumberView()
+struct QuizNumberView_Previews: PreviewProvider {
+    @State static var quizNumber = 3
+    
+    static var previews: some View {
+        QuizNumberView(quizNumber: $quizNumber, quizData: [PrimeQuizEntity(quizId: 0, number: 3, isCorrect: true)])
+    }
 }

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -12,8 +12,12 @@ struct QuizNumberView: View {
     let quizData: [PrimeQuizEntity]
     
     var body: some View {
-        Text(quizData[quizNumber].number.description)
-            .font(.custom("ArialRoundedMTBold", size: 180))
+        ZStack {
+            Color.cyan
+            
+            Text(quizData[quizNumber].number.description)
+                .font(.custom("ArialRoundedMTBold", size: 180))
+        }
     }
 }
 

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -25,6 +25,7 @@ struct QuizNumberView: View {
             
             Text(quizData[quizNumber].number.description)
                 .font(.custom("ArialRoundedMTBold", size: 180))
+                .foregroundStyle(Color.gray)
         }
     }
 }

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -13,6 +13,7 @@ struct QuizNumberView: View {
     
     var body: some View {
         Text(quizData[quizNumber].number.description)
+            .font(.custom("ArialRoundedMTBold", size: 180))
     }
 }
 

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -14,6 +14,14 @@ struct QuizNumberView: View {
     var body: some View {
         ZStack {
             Color("appGreen")
+                .opacity(0.5)
+                .edgesIgnoringSafeArea(.all)
+            
+            RoundedRectangle(cornerRadius: 25)
+                .stroke(Color.green, lineWidth: 5) // 緑色の枠線と角丸
+                .background(RoundedRectangle(cornerRadius: 25).fill(Color.white)) // 背景を白にする
+                .frame(width: 300, height: 200) // フレームサイズを指定
+                .shadow(radius: 10) // シャドウを追加して立体感を出す
             
             Text(quizData[quizNumber].number.description)
                 .font(.custom("ArialRoundedMTBold", size: 180))

--- a/PrimePickApp/QuizNumberView.swift
+++ b/PrimePickApp/QuizNumberView.swift
@@ -1,0 +1,18 @@
+//
+//  QuizNumberView.swift
+//  PrimePickApp
+//
+//  Created by 村石 拓海 on 2024/05/17.
+//
+
+import SwiftUI
+
+struct QuizNumberView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    QuizNumberView()
+}

--- a/PrimePickApp/QuizView.swift
+++ b/PrimePickApp/QuizView.swift
@@ -9,13 +9,12 @@ import SwiftUI
 
 struct QuizView: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var quizNumber: Int = 0
     
     let primeData = PrimeData()
     let difficulty: String
     let manager = QuizDataManager()
     let quizData: [PrimeQuizEntity]
-
-    @State private var quizNumber: Int = 0
     
     init(difficulty: String) {
         self.difficulty = difficulty
@@ -24,6 +23,8 @@ struct QuizView: View {
 
     var body: some View {
         VStack {
+            Color.yellow
+                .frame(height: UIScreen.main.bounds.height / 3)
             Text(quizData[quizNumber].number.description)
             HStack {
                 if quizNumber < 9 {
@@ -52,6 +53,7 @@ struct QuizView: View {
                     Text("終わり")
                 }
             }
+            Spacer()
         }
         .onAppear {
             print(quizData)

--- a/PrimePickApp/QuizView.swift
+++ b/PrimePickApp/QuizView.swift
@@ -23,10 +23,12 @@ struct QuizView: View {
 
     var body: some View {
         VStack {
-            QuizNumberView()
-                .frame(height: UIScreen.main.bounds.height / 3)
-                .foregroundStyle(Color.gray)
-            Text(quizData[quizNumber].number.description)
+            QuizNumberView(
+                quizNumber: $quizNumber,
+                quizData: quizData
+            )
+            .frame(height: UIScreen.main.bounds.height / 3)
+            .foregroundStyle(Color.gray)
             HStack {
                 if quizNumber < 9 {
                     Button {

--- a/PrimePickApp/QuizView.swift
+++ b/PrimePickApp/QuizView.swift
@@ -28,7 +28,7 @@ struct QuizView: View {
                 quizData: quizData
             )
             .frame(height: UIScreen.main.bounds.height / 3)
-            .foregroundStyle(Color.gray)
+
             HStack {
                 if quizNumber < 9 {
                     Button {

--- a/PrimePickApp/QuizView.swift
+++ b/PrimePickApp/QuizView.swift
@@ -23,8 +23,9 @@ struct QuizView: View {
 
     var body: some View {
         VStack {
-            Color.yellow
+            QuizNumberView()
                 .frame(height: UIScreen.main.bounds.height / 3)
+                .foregroundStyle(Color.gray)
             Text(quizData[quizNumber].number.description)
             HStack {
                 if quizNumber < 9 {

--- a/PrimePickApp/QuizView.swift
+++ b/PrimePickApp/QuizView.swift
@@ -11,7 +11,6 @@ struct QuizView: View {
     @Environment(\.dismiss) private var dismiss
     
     let primeData = PrimeData()
-    var primes: [Int]
     let difficulty: String
     let manager = QuizDataManager()
     let quizData: [PrimeQuizEntity]
@@ -20,15 +19,6 @@ struct QuizView: View {
     
     init(difficulty: String) {
         self.difficulty = difficulty
-        if self.difficulty == "Easy" {
-            primes = primeData.generateOneOrTwoDigitPrimes()
-        } else if self.difficulty == "Normal" {
-            primes = primeData.generateThreeDigitPrimes()
-        } else if self.difficulty == "Hard" {
-            primes = primeData.generateFourDigitPrimes()
-        } else {
-            primes = []
-        }
         quizData = manager.makeQuizData()
     }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
問題の数字を上部に固定で表示
画面上部1/3 におくことにしました

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolve #48 

## 詳細 (Detail)
<img width="390" alt="スクリーンショット 2024-05-17 20 44 28" src="https://github.com/shilokuma-inc/prime-pick-ios/assets/40351476/d464df29-2513-4f37-97e1-7269d8a2b087">


<!-- Thank you for your contribution! -->
