### PR TITLE
【FEAT】正当数を10問目の回答後に表示

### DIFF
--- a/PrimePickApp/QuizButtonView.swift
+++ b/PrimePickApp/QuizButtonView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct QuizButtonView: View {
     var quizData: [PrimeQuizEntity]
+    @State private var correctQuizNumber: Int = 0
     @Binding var quizNumber: Int
     @State private var showAlert = false
 
@@ -31,6 +32,7 @@ struct QuizButtonView: View {
                     print("❌")
                     if !quizData[quizNumber].isCorrect {
                         print("正解")
+                        correctQuizNumber += 1
                     } else {
                         print("不正解")
                     }
@@ -59,6 +61,7 @@ struct QuizButtonView: View {
                     print("✅")
                     if quizData[quizNumber].isCorrect {
                         print("正解")
+                        correctQuizNumber += 1
                     } else {
                         print("不正解")
                     }
@@ -76,7 +79,7 @@ struct QuizButtonView: View {
         }
         .alert(isPresented: $showAlert) {
             Alert(
-                title: Text("アラート"),
+                title: Text("You Score is \(correctQuizNumber) points!"),
                 dismissButton: .default(Text("OK"))
             )
         }

--- a/PrimePickApp/QuizButtonView.swift
+++ b/PrimePickApp/QuizButtonView.swift
@@ -12,6 +12,7 @@ struct QuizButtonView: View {
     @State private var correctQuizNumber: Int = 0
     @Binding var quizNumber: Int
     @State private var showAlert = false
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         ZStack {
@@ -80,7 +81,9 @@ struct QuizButtonView: View {
         .alert(isPresented: $showAlert) {
             Alert(
                 title: Text("You Score is \(correctQuizNumber) points!"),
-                dismissButton: .default(Text("OK"))
+                dismissButton: .default(Text("OK!")) {
+                    dismiss()
+                }
             )
         }
     }

--- a/PrimePickApp/QuizButtonView.swift
+++ b/PrimePickApp/QuizButtonView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct QuizButtonView: View {
     var quizData: [PrimeQuizEntity]
     @Binding var quizNumber: Int
+    @State private var showAlert = false
 
     var body: some View {
         ZStack {
@@ -37,6 +38,8 @@ struct QuizButtonView: View {
                         if quizNumber < 9 {
                             quizNumber += 1
                         }
+                    } else {
+                        showAlert = true
                     }
                 }
                 
@@ -63,11 +66,19 @@ struct QuizButtonView: View {
                         if quizNumber < 9 {
                             quizNumber += 1
                         }
+                    } else {
+                        showAlert = true
                     }
                 }
                 
                 Spacer()
             }
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(
+                title: Text("アラート"),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
正当数を10問目の回答後に表示

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolve #58 

## 詳細 (Detail)
<!-- Thank you for your contribution! -->
だいぶしょぼいけど..w
![simulator_screenshot_50979EF7-E3F3-4079-B81E-C1BA209681D1](https://github.com/shilokuma-inc/prime-pick-ios/assets/40351476/4c0c1872-06c4-4de0-a834-66545ca76b1f)

<!-- スクリーンショットテンプレート
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="320" alt="ファイル名" src="URL"></td>
    <td><img width="320" alt="ファイル名" src="URL"></td>
  </tr>
</table>
-->