### PR TITLE
【FEAT】結果表示をアラートではなく専用のViewで見せる

### DIFF
--- a/PrimePickApp.xcodeproj/project.pbxproj
+++ b/PrimePickApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4F65A3992C01019000065A53 /* Difficulty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F65A3982C01019000065A53 /* Difficulty.swift */; };
 		4F8BE16C2BF4FFB000D7CF0E /* PrimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8BE16B2BF4FFB000D7CF0E /* PrimeData.swift */; };
 		4F8BE16E2BF504BB00D7CF0E /* QuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */; };
+		4F8DC1842C08D66200247F62 /* QuizResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8DC1832C08D66200247F62 /* QuizResultView.swift */; };
 		4FEC65B12C01164800A8B731 /* SelectDifficultyButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEC65B02C01164800A8B731 /* SelectDifficultyButtonView.swift */; };
 		4FEC65B42C01184E00A8B731 /* Text+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEC65B32C01184E00A8B731 /* Text+Extension.swift */; };
 /* End PBXBuildFile section */
@@ -42,6 +43,7 @@
 		4F65A3982C01019000065A53 /* Difficulty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Difficulty.swift; sourceTree = "<group>"; };
 		4F8BE16B2BF4FFB000D7CF0E /* PrimeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeData.swift; sourceTree = "<group>"; };
 		4F8BE16D2BF504BB00D7CF0E /* QuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizView.swift; sourceTree = "<group>"; };
+		4F8DC1832C08D66200247F62 /* QuizResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultView.swift; sourceTree = "<group>"; };
 		4FC177B82BEEAB2C00447A06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4FEC65B02C01164800A8B731 /* SelectDifficultyButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectDifficultyButtonView.swift; sourceTree = "<group>"; };
 		4FEC65B32C01184E00A8B731 /* Text+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Extension.swift"; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				4F42C7A32BF76E7700F92FBB /* QuizNumberView.swift */,
 				4F2239212BFC9DEB004C71A6 /* QuizTimeLimitView.swift */,
 				4F2239232BFCEEF0004C71A6 /* QuizButtonView.swift */,
+				4F8DC1832C08D66200247F62 /* QuizResultView.swift */,
 			);
 			path = Quiz;
 			sourceTree = "<group>";
@@ -220,6 +223,7 @@
 			files = (
 				4F42C7A42BF76E7700F92FBB /* QuizNumberView.swift in Sources */,
 				4F2239242BFCEEF0004C71A6 /* QuizButtonView.swift in Sources */,
+				4F8DC1842C08D66200247F62 /* QuizResultView.swift in Sources */,
 				4F2239262BFD0873004C71A6 /* QuizIndexView.swift in Sources */,
 				4F02A57D2BF62F61003DF310 /* PrimeQuizEntity.swift in Sources */,
 				4F65A3992C01019000065A53 /* Difficulty.swift in Sources */,

--- a/PrimePickApp/View/Quiz/QuizButtonView.swift
+++ b/PrimePickApp/View/Quiz/QuizButtonView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct QuizButtonView: View {
     var quizData: [PrimeQuizEntity]
-    @State private var correctQuizNumber: Int = 0
+    @Binding var correctQuizNumber: Int
     @Binding var quizIndex: Int
     @Binding var isPresentedResult: Bool
     @State private var showAlert = false

--- a/PrimePickApp/View/Quiz/QuizButtonView.swift
+++ b/PrimePickApp/View/Quiz/QuizButtonView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct QuizButtonView: View {
     var quizData: [PrimeQuizEntity]
     @State private var correctQuizNumber: Int = 0
-    @Binding var quizNumber: Int
+    @Binding var quizIndex: Int
     @State private var showAlert = false
     @Environment(\.dismiss) private var dismiss
 
@@ -31,15 +31,15 @@ struct QuizButtonView: View {
                 }
                 .onTapGesture {
                     print("❌")
-                    if !quizData[quizNumber].isCorrect {
+                    if !quizData[quizIndex].isCorrect {
                         print("正解")
                         correctQuizNumber += 1
                     } else {
                         print("不正解")
                     }
-                    if quizNumber < 9 {
-                        if quizNumber < 9 {
-                            quizNumber += 1
+                    if quizIndex < 9 {
+                        if quizIndex < 9 {
+                            quizIndex += 1
                         }
                     } else {
                         showAlert = true
@@ -51,15 +51,15 @@ struct QuizButtonView: View {
                 quizButton(option: "Correct")
                 .onTapGesture {
                     print("✅")
-                    if quizData[quizNumber].isCorrect {
+                    if quizData[quizIndex].isCorrect {
                         print("正解")
                         correctQuizNumber += 1
                     } else {
                         print("不正解")
                     }
-                    if quizNumber < 9 {
-                        if quizNumber < 9 {
-                            quizNumber += 1
+                    if quizIndex < 9 {
+                        if quizIndex < 9 {
+                            quizIndex += 1
                         }
                     } else {
                         showAlert = true

--- a/PrimePickApp/View/Quiz/QuizButtonView.swift
+++ b/PrimePickApp/View/Quiz/QuizButtonView.swift
@@ -11,6 +11,7 @@ struct QuizButtonView: View {
     var quizData: [PrimeQuizEntity]
     @State private var correctQuizNumber: Int = 0
     @Binding var quizIndex: Int
+    @Binding var isPresentedResult: Bool
     @State private var showAlert = false
     @Environment(\.dismiss) private var dismiss
 
@@ -42,7 +43,8 @@ struct QuizButtonView: View {
                             quizIndex += 1
                         }
                     } else {
-                        showAlert = true
+//                        showAlert = true
+                        isPresentedResult = true
                     }
                 }
                 
@@ -62,7 +64,8 @@ struct QuizButtonView: View {
                             quizIndex += 1
                         }
                     } else {
-                        showAlert = true
+//                        showAlert = true
+                        isPresentedResult = true
                     }
                 }
                 

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct QuizResultView: View {
+    @Environment(\.dismiss) private var dismiss
     let score: Int
     
     var body: some View {

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -12,7 +12,22 @@ struct QuizResultView: View {
     let score: Int
     
     var body: some View {
-        Text("You Score is \(score) points!")
+        GeometryReader { geometry in
+            ZStack {
+                Color.green
+                    .frame(
+                        width: geometry.size.width * 2 / 3,
+                        height: geometry.size.height / 2
+                    )
+                
+                Text("Your Score is \(score) points!")
+            }
+            .frame(
+                width: geometry.size.width,
+                height: geometry.size.height
+            )
+        }
+        .edgesIgnoringSafeArea(.all)
     }
 }
 

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -9,26 +9,56 @@ import SwiftUI
 
 struct QuizResultView: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var rainbowColor: Color = .red
+    @State private var animationAngle: Double = 0
     let score: Int
     
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                Color.green
+                Color.appBackground
                     .frame(
                         width: geometry.size.width * 2 / 3,
                         height: geometry.size.height / 2
                     )
+                    .cornerRadius(20)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(rainbowColor, lineWidth: 5)
+                    )
+                    .onAppear {
+                        withAnimation(Animation.linear(duration: 2).repeatForever(autoreverses: false)) {
+                            animationAngle = 360
+                        }
+                    }
                 
                 Text("Your Score is \(score) points!")
+                    .frame(
+                        width: geometry.size.width / 2,
+                        height: geometry.size.height / 2
+                    )
+                    .font(.title)
+                    .multilineTextAlignment(.center)
             }
-            .frame(
-                width: geometry.size.width,
-                height: geometry.size.height
-            )
+            .frame(width: geometry.size.width, height: geometry.size.height)
         }
         .edgesIgnoringSafeArea(.all)
+        .onAppear {
+            startColorAnimation()
+        }
     }
+    
+    private func startColorAnimation() {
+            let colors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple]
+            var currentIndex = 0
+
+            Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { timer in
+                withAnimation {
+                    rainbowColor = colors[currentIndex]
+                }
+                currentIndex = (currentIndex + 1) % colors.count
+            }
+        }
 }
 
 #Preview {

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -49,16 +49,16 @@ struct QuizResultView: View {
     }
     
     private func startColorAnimation() {
-            let colors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple]
-            var currentIndex = 0
+        let colors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple]
+        var currentIndex = 0
 
-            Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { timer in
-                withAnimation {
-                    rainbowColor = colors[currentIndex]
-                }
-                currentIndex = (currentIndex + 1) % colors.count
+        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { timer in
+            withAnimation {
+                rainbowColor = colors[currentIndex]
             }
+            currentIndex = (currentIndex + 1) % colors.count
         }
+    }
 }
 
 #Preview {

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -32,13 +32,32 @@ struct QuizResultView: View {
                         }
                     }
                 
-                Text("Your Score is \(score) points!")
-                    .frame(
-                        width: geometry.size.width / 2,
-                        height: geometry.size.height / 2
-                    )
-                    .font(.title)
-                    .multilineTextAlignment(.center)
+                VStack {
+                    Text("Your Score is \(score) points!")
+                        .frame(
+                            width: geometry.size.width / 2,
+                            height: geometry.size.height / 4
+                        )
+                        .font(.title)
+                        .multilineTextAlignment(.center)
+                    
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 25)
+                            .stroke(Color.primary, lineWidth: 5)
+                            .frame(
+                                width: geometry.size.width / 2,
+                                height: 60
+                            )
+                            .background(
+                                RoundedRectangle(cornerRadius: 25)
+                                    .fill(Color.primary.opacity(0.1))
+                            )
+                            .shadow(radius: 10)
+                        
+                        Text("Return to Title")
+                            .font(.custom("ArialRoundedMTBold", size: 24))
+                    }
+                }
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
         }

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -57,6 +57,9 @@ struct QuizResultView: View {
                         Text("Return to Title")
                             .font(.custom("ArialRoundedMTBold", size: 24))
                     }
+                    .onTapGesture {
+                        dismiss()
+                    }
                 }
             }
             .frame(width: geometry.size.width, height: geometry.size.height)

--- a/PrimePickApp/View/Quiz/QuizResultView.swift
+++ b/PrimePickApp/View/Quiz/QuizResultView.swift
@@ -1,0 +1,20 @@
+//
+//  QuizResultView.swift
+//  PrimePickApp
+//
+//  Created by 村石 拓海 on 2024/05/31.
+//
+
+import SwiftUI
+
+struct QuizResultView: View {
+    let score: Int
+    
+    var body: some View {
+        Text("You Score is \(score) points!")
+    }
+}
+
+#Preview {
+    QuizResultView(score: 1)
+}

--- a/PrimePickApp/View/Quiz/QuizView.swift
+++ b/PrimePickApp/View/Quiz/QuizView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct QuizView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var quizNumber: Int = 0
+    @State var isPresentedResult: Bool = false
     
     let primeData = PrimeData()
     let difficulty: Difficulty
@@ -42,13 +43,21 @@ struct QuizView: View {
                 
                 Spacer()
                 
-                QuizButtonView(quizData: quizData, quizIndex: $quizNumber)
-                    .frame(height: UIScreen.main.bounds.height / 3)
+                QuizButtonView(
+                    quizData: quizData,
+                    quizIndex: $quizNumber,
+                    isPresentedResult: $isPresentedResult
+                )
+                .frame(height: UIScreen.main.bounds.height / 3)
                 
                 Spacer()
             }
             .onAppear {
                 print(quizData)
+            }
+            
+            if isPresentedResult {
+                QuizResultView(score: 6)
             }
         }
     }

--- a/PrimePickApp/View/Quiz/QuizView.swift
+++ b/PrimePickApp/View/Quiz/QuizView.swift
@@ -42,7 +42,7 @@ struct QuizView: View {
                 
                 Spacer()
                 
-                QuizButtonView(quizData: quizData, quizNumber: $quizNumber)
+                QuizButtonView(quizData: quizData, quizIndex: $quizNumber)
                     .frame(height: UIScreen.main.bounds.height / 3)
                 
                 Spacer()

--- a/PrimePickApp/View/Quiz/QuizView.swift
+++ b/PrimePickApp/View/Quiz/QuizView.swift
@@ -11,6 +11,7 @@ struct QuizView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var quizNumber: Int = 0
     @State var isPresentedResult: Bool = false
+    @State var resultScore: Int = 0
     
     let primeData = PrimeData()
     let difficulty: Difficulty
@@ -45,6 +46,7 @@ struct QuizView: View {
                 
                 QuizButtonView(
                     quizData: quizData,
+                    correctQuizNumber: $resultScore,
                     quizIndex: $quizNumber,
                     isPresentedResult: $isPresentedResult
                 )
@@ -57,7 +59,7 @@ struct QuizView: View {
             }
             
             if isPresentedResult {
-                QuizResultView(score: 6)
+                QuizResultView(score: resultScore)
             }
         }
     }


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
結果表示をアラートではなく専用のViewで見せる

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolve #83 

## 詳細 (Detail)
<!-- Thank you for your contribution! -->

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="320" alt="ファイル名" src="URL"></td>
    <td><img width="320" alt="ファイル名" src="https://github.com/shilokuma-inc/prime-pick-ios/assets/40351476/5bc6c1ab-7091-4924-9593-15857e03ef67"></td>
  </tr>
</table>
