### PR TITLE
【FIX】クリア後もボタンを押し続けるとスコアが増えてしまう問題の修正

### DIFF
--- a/PrimePickApp/View/Quiz/QuizButtonView.swift
+++ b/PrimePickApp/View/Quiz/QuizButtonView.swift
@@ -22,11 +22,13 @@ struct QuizButtonView: View {
                 quizButton(option: "Incorrect")
                 .onTapGesture {
                     print("❌")
-                    if !quizData[quizIndex].isCorrect {
-                        print("正解")
-                        correctQuizNumber += 1
-                    } else {
-                        print("不正解")
+                    if !isPresentedResult {
+                        if !quizData[quizIndex].isCorrect {
+                            print("正解")
+                            correctQuizNumber += 1
+                        } else {
+                            print("不正解")
+                        }
                     }
                     if quizIndex < 9 {
                         quizIndex += 1
@@ -40,11 +42,13 @@ struct QuizButtonView: View {
                 quizButton(option: "Correct")
                 .onTapGesture {
                     print("✅")
-                    if quizData[quizIndex].isCorrect {
-                        print("正解")
-                        correctQuizNumber += 1
-                    } else {
-                        print("不正解")
+                    if !isPresentedResult {
+                        if quizData[quizIndex].isCorrect {
+                            print("正解")
+                            correctQuizNumber += 1
+                        } else {
+                            print("不正解")
+                        }
                     }
                     if quizIndex < 9 {
                         quizIndex += 1

--- a/PrimePickApp/View/Quiz/QuizButtonView.swift
+++ b/PrimePickApp/View/Quiz/QuizButtonView.swift
@@ -12,7 +12,6 @@ struct QuizButtonView: View {
     @Binding var correctQuizNumber: Int
     @Binding var quizIndex: Int
     @Binding var isPresentedResult: Bool
-    @State private var showAlert = false
 
     var body: some View {
         ZStack {
@@ -21,7 +20,6 @@ struct QuizButtonView: View {
                 
                 quizButton(option: "Incorrect")
                 .onTapGesture {
-                    print("❌")
                     if !isPresentedResult {
                         if !quizData[quizIndex].isCorrect {
                             print("正解")
@@ -41,7 +39,6 @@ struct QuizButtonView: View {
                 
                 quizButton(option: "Correct")
                 .onTapGesture {
-                    print("✅")
                     if !isPresentedResult {
                         if quizData[quizIndex].isCorrect {
                             print("正解")


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
クリア後もボタンを押し続けるとスコアが増えてしまう問題の修正
- 結果画面が出た場合、ボタンを押しても反応しないように変更

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolve #90

## 詳細 (Detail)
<!-- Thank you for your contribution! -->

<!-- スクリーンショットテンプレート
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="320" alt="ファイル名" src="URL"></td>
    <td><img width="320" alt="ファイル名" src="URL"></td>
  </tr>
</table>
-->